### PR TITLE
BENCH-556_build-docker-with-ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3.7
+FROM ubuntu:latest
 COPY alertmanager2hangoutschat /
-RUN apk add --no-cache ca-certificates
+RUN apt-get update
+RUN apt-get install -y ca-certificates
 ENTRYPOINT ["/alertmanager2hangoutschat"]


### PR DESCRIPTION
It fixes the docker file for alertmanager2hangoutschat. Following of this PR: https://github.com/Pix4D/terraform-tomato/pull/377
